### PR TITLE
Parser improvements

### DIFF
--- a/generate/update.php
+++ b/generate/update.php
@@ -3,7 +3,7 @@
 	
 	set_time_limit( 300 );
 	
-	$IncludeGLOB = __DIR__ . '/include/*.inc';
+	$IncludeGLOB = __DIR__ . '/../include/*.inc';
 	
 	/**
 	 * @section Parse files and construct arrays of functions and constants
@@ -53,7 +53,7 @@
 			++$Count;
 			
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
-			$IsFunction = preg_match( '/^(stock|native|forward)(?!\s*const\s)/', $Line ) === 1;
+			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+(\w+:(\[\d*\]))?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;			
 			
 			if( $FunctionUntilNextCommentBlock )
 			{
@@ -74,7 +74,7 @@
 						'CommentTags' => ParseTags( $Comment[ 1 ] )
 					);
 					
-					else if( $IsFunction )
+					if( $IsFunction )
 					{
 						$FunctionBuffer[ ] = $Line;
 						
@@ -374,6 +374,11 @@
 		
 		$PositionStart = strrpos( $Line, ':' );
 		
+		if( preg_match('/(:\[\d*?\])/', $Line, $matches, PREG_OFFSET_CAPTURE) == 1)
+		{
+				$PositionStart = strrpos($Line, $matches[0][0]) + strlen($matches[0][0]);
+		}
+		
 		if( $PositionStart === false )
 		{
 			$PositionStart = strrpos( $Line, ' ' );
@@ -499,3 +504,7 @@
 	/**
 	 * @endsection
 	 */
+
+
+
+

--- a/generate/update.php
+++ b/generate/update.php
@@ -54,7 +54,10 @@
 			
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
 			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+(\w+:(\[\d*\])?)?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;
-			
+
+			if(preg_match('/\#pragma/', $Line))
+				continue;
+
 			if( $FunctionUntilNextCommentBlock )
 			{
 				if( $IsFunction || $IsCommentOpening || $Count === $Lines )

--- a/generate/update.php
+++ b/generate/update.php
@@ -56,7 +56,7 @@
 				continue;
 
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
-			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+(\w+:(\[\d*\])?)?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;
+			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+((\w+:)?(\[[\d\w]*\])?)?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;
 
 			if( $FunctionUntilNextCommentBlock )
 			{

--- a/generate/update.php
+++ b/generate/update.php
@@ -53,7 +53,7 @@
 			++$Count;
 			
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
-			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+(\w+:(\[\d*\]))?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;			
+			$IsFunction = preg_match( '/^((stock|native|forward|public)\s+)+(\w+:(\[\d*\])?)?\s*\w+\s*\(([^\)]*)\);?$/', $Line ) === 1;
 			
 			if( $FunctionUntilNextCommentBlock )
 			{
@@ -346,25 +346,7 @@
 	
 	function RemoveWhitespace( $Original, $Line )
 	{
-		if( strpos( $Line, "\n" ) !== false )
-		{
-			$Position = strpos( $Original, $Line );
-			
-			$Line = explode( "\n", $Line );
-			
-			foreach( $Line as &$Line2 )
-			{
-				// Remove whitespace
-				if( preg_match( '/^\s+$/', substr( $Line2, 0, $Position ) ) === 1 )
-				{
-					$Line2 = substr( $Line2, $Position );
-				}
-			}
-			
-			$Line = implode( "\n", $Line );
-		}
-		
-		return $Line;
+		return preg_replace('/\s+/', ' ', $Line);
 	}
 	
 	function GetFunctionName( $Line )
@@ -378,7 +360,7 @@
 		{
 				$PositionStart = strrpos($Line, $matches[0][0]) + strlen($matches[0][0]);
 		}
-		
+
 		if( $PositionStart === false )
 		{
 			$PositionStart = strrpos( $Line, ' ' );

--- a/generate/update.php
+++ b/generate/update.php
@@ -42,7 +42,6 @@
 		$InSection = false;
 		$OpenComment = false;
 		$FunctionUntilNextCommentBlock = false;
-		$MethodMapBuffer = Array();
 		$CommentBlock = Array();
 		$FunctionBuffer = Array();
 		
@@ -54,7 +53,7 @@
 			++$Count;
 			
 			$IsCommentOpening = substr( $Line, 0, 2 ) === '/*';
-			$IsFunction = preg_match( '/^(stock|functag|native|forward|methodmap)(?!\s*const\s)/', $Line ) === 1;
+			$IsFunction = preg_match( '/^(stock|native|forward)(?!\s*const\s)/', $Line ) === 1;
 			
 			if( $FunctionUntilNextCommentBlock )
 			{
@@ -75,14 +74,6 @@
 						'CommentTags' => ParseTags( $Comment[ 1 ] )
 					);
 					
-					if( substr( $Line, 0, 9 ) === 'methodmap' )
-					{
-						$MethodMapBuffer[ ] = $Line;
-						
-						$Function[ 'FunctionName' ] = GetMethodMapName( $Line );
-						
-						$MethodMapUntilEnd = true;
-					}
 					else if( $IsFunction )
 					{
 						$FunctionBuffer[ ] = $Line;
@@ -114,21 +105,6 @@
 				else
 				{
 					$FunctionBuffer[ ] = $Line;
-				}
-			}
-			else if( !empty( $MethodMapBuffer ) )
-			{
-				$MethodMapBuffer[ ] = $Line;
-				
-				if( $Line === '}' )
-				{
-					$Function[ 'Function' ] = implode( "\n", $MethodMapBuffer );
-					
-					$Functions[ ] = $Function;
-					
-					print_r( $Function );
-					
-					$MethodMapBuffer = Array();
 				}
 			}
 			else if( !$IsCommentOpening && $IsFunction )
@@ -412,19 +388,6 @@
 		);
 	}
 	
-	function GetMethodMapName( $Line )
-	{
-		$Line = substr( $Line, 10 );
-		
-		$PositionEnd = strpos( $Line, ' ' );
-		
-		$FunctionName = trim( substr( $Line, 0, $PositionEnd ) );
-		
-		return Array(
-			$FunctionName,
-			$FunctionName
-		);
-	}
 	
 	function ConvertTabsToSpaces( $Text )
 	{


### PR DESCRIPTION
- Not sure about RemoveWhitespace but my tests passed fine.
- Truncate required to remove outdated info from database
- Functag and methodmaps are sourcepawn constructions
- Parser now not fucking up natives with "tag:" and even "tag:[1337]", will add "tag:[const_array_size]" later for `native [MAX_FMT_LENGTH]fmt(const format[], any:...);`
- "This function has no description." must be in template